### PR TITLE
Type checking

### DIFF
--- a/client/src/data/TaskStore.js
+++ b/client/src/data/TaskStore.js
@@ -1,14 +1,18 @@
 import { ReduceStore } from "flux/utils";
+import PropTypes from "prop-types";
 import Dispatcher from './dispatcher';
 import TaskActions from "./TaskActions";
 import LoadObject from "../util/LoadObject";
 import TaskApi from "./TaskApi";
 import hotLoadObject from "../util/hotLoadObject";
-import ClientId from "../util/ClientId";
+import ClientId, { clientOrDatabaseIdType } from "../util/ClientId";
 import { humanStringComparator } from "../util/comparators";
 import PreferencesStore from "./PreferencesStore";
 import dotProp from "dot-prop-immutable";
 import UserStore from "./UserStore";
+import typedStore from "../util/typedStore";
+import loadObjectOf from "../util/loadObjectOf";
+import AccessLevel from "./AccessLevel";
 
 /*
  * This store is way too muddled. But leaving it that way for the moment, to
@@ -811,4 +815,28 @@ class TaskStore extends ReduceStore {
     }
 }
 
-export default new TaskStore();
+TaskStore.stateTypes = {
+    activeListId: clientOrDatabaseIdType,
+    listDetailVisible: PropTypes.bool.isRequired,
+    activeTaskId: clientOrDatabaseIdType,
+    selectedTaskIds: PropTypes.arrayOf(clientOrDatabaseIdType),
+    topLevelIds: loadObjectOf(
+        PropTypes.arrayOf(clientOrDatabaseIdType)
+    ),
+    byId: PropTypes.objectOf(
+        loadObjectOf(PropTypes.exact({
+            id: clientOrDatabaseIdType.isRequired,
+            name: PropTypes.string.isRequired,
+            acl: PropTypes.exact({
+                ownerId: PropTypes.number.isRequired,
+                grants: PropTypes.objectOf(
+                    PropTypes.oneOf(Object.values(AccessLevel))
+                ),
+            }),
+            parentId: PropTypes.number,
+            subtaskIds: PropTypes.arrayOf(clientOrDatabaseIdType),
+        }))
+    ).isRequired,
+};
+
+export default typedStore(new TaskStore());

--- a/client/src/data/UserActions.js
+++ b/client/src/data/UserActions.js
@@ -1,8 +1,18 @@
+import PropTypes from "prop-types";
+import typedAction from "../util/typedAction";
+
 const UserActions = {
     LOGGED_IN: "user/logged-in",
     LOGOUT: "user/logout",
     LOAD_PROFILE: "user/load-profile",
-    PROFILE_LOADED: "user/profile-loaded",
+    PROFILE_LOADED: typedAction("user/profile-loaded", {
+        data: PropTypes.shape({
+            id: PropTypes.number.isRequired,
+            name: PropTypes.string,
+            email: PropTypes.string.isRequired,
+            imageUrl: PropTypes.string,
+        }).isRequired
+    }),
     PROFILE_LOAD_ERROR: "user/profile-load-error",
     RESTORE_PREFERENCES: "user/restore-preferences",
 };

--- a/client/src/data/ValidatingDispatcher.js
+++ b/client/src/data/ValidatingDispatcher.js
@@ -1,0 +1,23 @@
+import { Dispatcher } from "flux";
+import PropTypes from "prop-types";
+import { CONTAINER_KEY } from "../util/typedAction";
+
+const checkPayload = payload => {
+    if (payload.type == null) {
+        throw new Error("Actions must have a 'type' key");
+    }
+    if (payload.type.actionTypes != null) {
+        PropTypes.checkPropTypes(payload.type.actionTypes, {[CONTAINER_KEY]: payload}, "actionTypes", payload.type);
+    }
+};
+
+class ValidatingDispatcher extends Dispatcher {
+
+    dispatch(payload) {
+        checkPayload(payload);
+        super.dispatch(payload);
+    }
+
+}
+
+export default ValidatingDispatcher;

--- a/client/src/data/dispatcher.js
+++ b/client/src/data/dispatcher.js
@@ -1,3 +1,6 @@
-import {Dispatcher} from 'flux';
+import { Dispatcher } from 'flux';
+import ValidatingDispatcher from "./ValidatingDispatcher";
 
-export default new Dispatcher();
+export default process.env.NODE_ENV === "production"
+    ? new Dispatcher()
+    : new ValidatingDispatcher();

--- a/client/src/util/ClientId.js
+++ b/client/src/util/ClientId.js
@@ -1,4 +1,8 @@
 import PropTypes from "prop-types";
+import {
+    createChainableTypeChecker,
+    PropTypeError,
+} from "./typeHelpers";
 
 const NOISE = Math.floor(Math.random() * 100000); // ~5 random digits
 const PREFIX = "c_" + NOISE + "_";
@@ -20,12 +24,12 @@ const ClientId = {
         return !ClientId.is(id);
     },
 
-    propType(props, propName) {
+    propType: createChainableTypeChecker((props, propName) => {
         if (ClientId.is(props[propName])) {
             return;
         }
-        return new Error(`'${propName}' isn't a valid ClientId`);
-    },
+        return new PropTypeError(`'${propName}' isn't a valid ClientId`);
+    }),
 
 };
 

--- a/client/src/util/loadObjectOf.js
+++ b/client/src/util/loadObjectOf.js
@@ -1,0 +1,49 @@
+import RPTSecret from "prop-types/lib/ReactPropTypesSecret";
+import {
+    createChainableTypeChecker,
+    getClassName,
+    PropTypeError,
+} from "./typeHelpers";
+import LoadObject from "./LoadObject";
+
+const loadObjectOf = (valueTypeChecker, optionalErrorTypeChecker) =>
+    createChainableTypeChecker((
+        props,
+        propName,
+        componentName,
+        location,
+        propFullName,
+    ) => {
+        if (typeof valueTypeChecker !== 'function' || (optionalErrorTypeChecker != null && typeof optionalErrorTypeChecker !== 'function')) {
+            return new PropTypeError('Property `' + propFullName + '` of component `' + componentName + '` has invalid PropType notation inside loadObjectOf.');
+        }
+        const lo = props[propName];
+        if (!(lo instanceof LoadObject)) {
+            return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type `' + getClassName(lo) + '` supplied to `' + componentName + '`, expected instance of `LoadObject`.');
+        }
+        if (lo.hasValue()) {
+            const error = valueTypeChecker(
+                {value: lo.getValueEnforcing()},
+                "value",
+                "LoadObject",
+                location,
+                propFullName + ".value",
+                RPTSecret,
+            );
+            if (error != null) return error;
+        }
+        if (optionalErrorTypeChecker != null && lo.hasError()) {
+            const error = valueTypeChecker(
+                {error: lo.getErrorEnforcing()},
+                "error",
+                "LoadObject",
+                location,
+                propFullName + ".error",
+                RPTSecret,
+            );
+            if (error != null) return error;
+        }
+        return null;
+    });
+
+export default loadObjectOf;

--- a/client/src/util/typeHelpers.js
+++ b/client/src/util/typeHelpers.js
@@ -1,0 +1,68 @@
+//////////////////////////////////////////////////////////////////////
+// This file is taken directly from the `prop-types` library's
+// internals, so that our custom checkers can work the same as the
+// standard ones. It's not ideal, but they don't expose these details
+// via module exports, so we have to duplicate...
+//////////////////////////////////////////////////////////////////////
+
+const ANONYMOUS = "<<anonymous>>";
+
+/**
+ * We use an Error-like object for backward compatibility as people may call
+ * PropTypes directly and inspect their output. However, we don't use real
+ * Errors anymore. We don't inspect their stack anyway, and creating them
+ * is prohibitively expensive if they are created too often, such as what
+ * happens in oneOfType() for any type before the one that matched.
+ */
+export function PropTypeError(message) {
+    this.message = message;
+    this.stack = "";
+}
+
+// Make `instanceof Error` still work for returned errors.
+PropTypeError.prototype = Error.prototype;
+
+export function createChainableTypeChecker(validate) {
+    function checkType(
+        isRequired,
+        props,
+        propName,
+        componentName,
+        location,
+        propFullName,
+    ) {
+        componentName = componentName || ANONYMOUS;
+        propFullName = propFullName || propName;
+
+        if (props[propName] == null) {
+            if (isRequired) {
+                if (props[propName] === null) {
+                    return new PropTypeError(`The ${location} \`${propFullName}\` is marked as required in \`${componentName}\`, but its value is \`null\`.`);
+                }
+                return new PropTypeError(`The ${location} \`${propFullName}\` is marked as required in \`${componentName}\`, but its value is \`undefined\`.`);
+            }
+            return null;
+        } else {
+            return validate(
+                props,
+                propName,
+                componentName,
+                location,
+                propFullName,
+            );
+        }
+    }
+
+    const chainedCheckType = checkType.bind(null, false);
+    chainedCheckType.isRequired = checkType.bind(null, true);
+
+    return chainedCheckType;
+}
+
+// Returns class name of the object, if any.
+export  function getClassName(propValue) {
+    if (!propValue.constructor || !propValue.constructor.name) {
+        return ANONYMOUS;
+    }
+    return propValue.constructor.name;
+}

--- a/client/src/util/typedAction.js
+++ b/client/src/util/typedAction.js
@@ -1,0 +1,31 @@
+import PropTypes from "prop-types";
+
+export const CONTAINER_KEY = "payload";
+
+/*
+ * This function uses a bit of JS trickery in order to "hide" a proptypes def
+ * on a string, which will then be used by ValidatingDispatcher to validate that
+ * actions of this type are dispatched with the correct shape.
+ *
+ * NB: the 'type' key is implicitly allowed for any action.
+ *
+ * NB: the `exact` PropTypes checker is used, so extra keys will also surface
+ * complaints (you can't sometimes hide extra stuff in an action).
+ */
+const typedAction = (name, shape) => {
+    if (process.env.NODE_ENV !== "production" && shape != null) {
+        // noinspection JSPrimitiveTypeWrapperUsage
+        name = new String(name); // eslint-disable-line no-new-wrappers
+        // noinspection JSPrimitiveTypeWrapperUsage
+        name.actionTypes = {
+            [CONTAINER_KEY]: PropTypes.exact({
+                ...shape,
+                // PropTypes.string does primitives
+                type: PropTypes.instanceOf(String).isRequired,
+            }).isRequired,
+        };
+    }
+    return name;
+};
+
+export default typedAction;

--- a/client/src/util/typedStore.js
+++ b/client/src/util/typedStore.js
@@ -1,0 +1,49 @@
+import PropTypes from "prop-types";
+
+const builder = (self, method, typesKey, initial) => {
+    const name = self.constructor.name;
+    method = method.bind(self);
+    let typeSpecs = self.constructor[typesKey];
+    if (typeSpecs == null) {
+        throw new Error(`No ${typesKey} defined for ${name}; can't activate type checking.`);
+    }
+    // PropTypes doesn't allow you to declare type information where the
+    // top-level properties are anonymous, which is exactly what is needed for
+    // an "id lookup"-style Store. Rather than forcing the Store to deal with
+    // the extra layer just to get typechecking, assume that if the store's
+    // type info is a function, it's the result of an `objectOf` call for the
+    // top-level state object itself. The extra named layer will be created
+    // implicitly before validating. And, in fact, `objectOf` is in no way
+    // special; this mechanism will allow any checker to be used for a store.
+    typeSpecs = {
+        state: typeof typeSpecs === "function"
+            ? typeSpecs
+            : PropTypes.exact(typeSpecs),
+    };
+    const check = next =>
+        PropTypes.checkPropTypes(typeSpecs, {state: next}, typesKey, name);
+    if (initial != null) check(initial);
+    return (curr, action) => {
+        const next = method(curr, action);
+        if (!self.areEqual(curr, next)) check(next);
+        return next;
+    };
+};
+
+const typedStore = self => {
+    if (process.env.NODE_ENV !== "production") {
+        if (self.reduce) {
+            self.reduce = builder(
+                self,
+                self.reduce,
+                "stateTypes",
+                self.getInitialState(),
+            );
+        } else {
+            throw new Error("No 'reduce' method found on store.");
+        }
+    }
+    return self;
+};
+
+export default typedStore;


### PR DESCRIPTION
provide some more tools for checking types, in the prop-types style, but for actions, Stores, and LoadObjects.