### PR TITLE
Duplicate recipe

### DIFF
--- a/client/src/containers/Library.js
+++ b/client/src/containers/Library.js
@@ -12,12 +12,10 @@ export default Container.createFunctional(
         RecipeStore
     ],
     () => ({
-        recipes: RecipeStore.getState(),
         scope: LibraryStore.getState().scope,
         filter: LibraryStore.getState().filter,
         libraryLO: LibraryStore.getLibraryLO()
             .map(rs => rs.sort(humanStringComparator)),
-        stagedRecipes: LibraryStore.getStagedRecipes(),
         shoppingList: LibraryStore.getShoppingList(),
     })
 )

--- a/client/src/containers/Library.js
+++ b/client/src/containers/Library.js
@@ -19,6 +19,7 @@ export default Container.createFunctional(
         filter: LibraryStore.getState().filter,
         libraryLO: LibraryStore.getLibraryLO()
             .map(rs => rs.sort(humanStringComparator)),
+        stagedRecipes: LibraryStore.getStagedRecipes(),
         shoppingList: LibraryStore.getShoppingList(),
     })
 )

--- a/client/src/containers/Library.js
+++ b/client/src/containers/Library.js
@@ -4,14 +4,17 @@ import RecipesList from '../views/RecipesList'
 import RecipeStore from '../data/RecipeStore'
 import LibraryStore from '../data/LibraryStore'
 import { humanStringComparator } from "../util/comparators"
+import UserStore from "../data/UserStore"
 
 export default Container.createFunctional(
     (props) => <RecipesList {...props}/>,
     () => [
+        UserStore,
         LibraryStore,
-        RecipeStore
+        RecipeStore,
     ],
     () => ({
+        me: UserStore.getProfileLO().getValueEnforcing(),
         scope: LibraryStore.getState().scope,
         filter: LibraryStore.getState().filter,
         libraryLO: LibraryStore.getLibraryLO()

--- a/client/src/containers/Recipe.js
+++ b/client/src/containers/Recipe.js
@@ -3,22 +3,28 @@ import { Container } from 'flux/utils'
 import { withRouter } from 'react-router-dom'
 import RecipeDetail from '../views/RecipeDetail'
 import RecipeStore from '../data/RecipeStore'
-import LibraryStore from "../data/LibraryStore"
+import LibraryStore, { isRecipeStaged } from "../data/LibraryStore"
+import UserStore from "../data/UserStore"
 
 export default withRouter(Container.createFunctional(
     (props) => <RecipeDetail {...props}/>,
     () => [
+        UserStore,
         LibraryStore,
         RecipeStore,
     ],
     (prevState, props) => {
         const { match } = props
         const id = parseInt(match.params.id, 10)
-        const recipeLO = LibraryStore.getRecipeById(id)
-        return {
-            recipeLO,
-            staged: LibraryStore.isStaged(id),
+        const lo = LibraryStore.getRecipeById(id)
+        const state = {recipeLO: lo}
+        if (lo.hasValue()) {
+            const me = UserStore.getProfileLO().getValueEnforcing()
+            const r = lo.getValueEnforcing()
+            state.mine = r.ownerId === me.id
+            state.staged = isRecipeStaged(r)
         }
+        return state
     },
     { withProps: true }
 ))

--- a/client/src/containers/Recipe.js
+++ b/client/src/containers/Recipe.js
@@ -5,11 +5,12 @@ import RecipeDetail from '../views/RecipeDetail'
 import RecipeStore from '../data/RecipeStore'
 import LibraryStore, { isRecipeStaged } from "../data/LibraryStore"
 import UserStore from "../data/UserStore"
+import FriendStore from "../data/FriendStore"
 
 export default withRouter(Container.createFunctional(
     (props) => <RecipeDetail {...props}/>,
     () => [
-        UserStore,
+        FriendStore,
         LibraryStore,
         RecipeStore,
     ],
@@ -19,9 +20,13 @@ export default withRouter(Container.createFunctional(
         const lo = LibraryStore.getRecipeById(id)
         const state = {recipeLO: lo}
         if (lo.hasValue()) {
-            const me = UserStore.getProfileLO().getValueEnforcing()
+            const profileLO = UserStore.getProfileLO()
+            const me = profileLO.getValueEnforcing()
             const r = lo.getValueEnforcing()
             state.mine = r.ownerId === me.id
+            state.ownerLO = state.mine
+                ? profileLO
+                : FriendStore.getFriendLO(r.ownerId)
             state.staged = isRecipeStaged(r)
         }
         return state

--- a/client/src/data/DraftRecipeStore.js
+++ b/client/src/data/DraftRecipeStore.js
@@ -13,12 +13,13 @@ const loadRecipeIfPossible = draftLO => {
     if (draftLO.isDone()) return draftLO
     const state = draftLO.getValueEnforcing()
     if (!state.id) return draftLO
-    const lo = LibraryStore.getRecipeById(state.id)
+    const lo = LibraryStore.getRecipeById(state.sourceId || state.id)
     if (!lo.hasValue()) return draftLO
     const recipe = lo.getValueEnforcing()
     return draftLO.setValue({
         ...state,
         ...recipe,
+        id: state.id, // in case it's a copy
     }).done().map(s => {
         if (s.ingredients == null || s.ingredients.length === 0) {
             s = {
@@ -54,6 +55,14 @@ class DraftRecipeStore extends ReduceStore {
                     case "/library/recipe/:id/edit": {
                         state = state.setValue({
                             id: parseInt(match.params.id),
+                        }).loading()
+                        return loadRecipeIfPossible(state)
+                    }
+
+                    case "/library/recipe/:id/make-copy": {
+                        state = state.setValue({
+                            id: ClientId.next(),
+                            sourceId: parseInt(match.params.id),
                         }).loading()
                         return loadRecipeIfPossible(state)
                     }

--- a/client/src/data/FriendStore.js
+++ b/client/src/data/FriendStore.js
@@ -52,6 +52,11 @@ class FriendStore extends ReduceStore {
         )
     }
 
+    getFriendLO(id) {
+        return this.getFriendsLO()
+            .map(fs => fs.find(f => f.id === id))
+    }
+
 }
 
 export default new FriendStore()

--- a/client/src/data/LibraryActions.js
+++ b/client/src/data/LibraryActions.js
@@ -7,7 +7,7 @@ const LibraryActions = {
     UNSTAGE_RECIPE: "library/unstage-recipe",
     SET_SCOPE: "library/set-scope",
     UPDATE_FILTER: "library/update-filter",
-    FILTER_LIBRARY: "library/filter-library"
+    FILTER_LIBRARY: "library/filter-library",
 }
 
 export default LibraryActions

--- a/client/src/data/LibraryActions.js
+++ b/client/src/data/LibraryActions.js
@@ -5,7 +5,6 @@ const LibraryActions = {
     INGREDIENT_LOADED: "library/ingredient-loaded",
     STAGE_RECIPE: "library/stage-recipe",
     UNSTAGE_RECIPE: "library/unstage-recipe",
-    UNSTAGE_ALL_RECIPES: "library/unstage-all-recipes",
     SET_SCOPE: "library/set-scope",
     UPDATE_FILTER: "library/update-filter",
     FILTER_LIBRARY: "library/filter-library"

--- a/client/src/data/LibraryStore.js
+++ b/client/src/data/LibraryStore.js
@@ -12,6 +12,7 @@ import {
     removeDistinct,
 } from "../util/arrayAsSet"
 import RecipeApi from "./RecipeApi"
+import UserStore from "./UserStore"
 
 export const SCOPE_MINE = "mine"
 export const SCOPE_EVERYONE = "everyone"
@@ -36,7 +37,7 @@ export const isRecipeStaged = r => {
         if (!r.hasValue()) return false
         r = r.getValueEnforcing()
     }
-    if (!r.labels) return false
+    if (r.labels == null) return false
     return r.labels.indexOf(LABEL_STAGED_INDICATOR) >= 0
 }
 
@@ -223,11 +224,12 @@ class LibraryStore extends ReduceStore {
     }
 
     getStagedRecipes() {
-        if (this.getState().scope !== SCOPE_MINE) return []
         const lo = this.getLibraryLO()
         if (!lo.hasValue()) return []
+        const me = UserStore.getProfileLO().getValueEnforcing()
         return lo.getValueEnforcing()
-            .filter(isRecipeStaged)
+            .filter(r =>
+                r.ownerId === me.id && isRecipeStaged(r))
     }
 
     isStaged(id) {

--- a/client/src/data/LibraryStore.js
+++ b/client/src/data/LibraryStore.js
@@ -224,12 +224,20 @@ class LibraryStore extends ReduceStore {
     }
 
     getStagedRecipes() {
-        const lo = this.getLibraryLO()
-        if (!lo.hasValue()) return []
+        // don't use the list of recipes, use all recipe ingredients, so it's
+        // exempt from filtering.
+        const map = this.getState().byId
+        const result = []
         const me = UserStore.getProfileLO().getValueEnforcing()
-        return lo.getValueEnforcing()
-            .filter(r =>
-                r.ownerId === me.id && isRecipeStaged(r))
+        for (const id of Object.keys(map)) {
+            const lo = map[id]
+            if (!lo.hasValue()) continue
+            const r = lo.getValueEnforcing()
+            if (r.ownerId === me.id && isRecipeStaged(r)) {
+                result.push(r)
+            }
+        }
+        return result
     }
 
     isStaged(id) {

--- a/client/src/data/LibraryStore.js
+++ b/client/src/data/LibraryStore.js
@@ -11,9 +11,34 @@ import {
     addDistinct,
     removeDistinct,
 } from "../util/arrayAsSet"
+import RecipeApi from "./RecipeApi"
 
 export const SCOPE_MINE = "mine"
 export const SCOPE_EVERYONE = "everyone"
+export const LABEL_STAGED_INDICATOR = "--on-stage"
+
+const workOnLabels = (state, recipeId, work) => {
+    const lo = state.byId[recipeId]
+    if (lo == null || !lo.hasValue()) return state
+    const r = lo.getValueEnforcing()
+    const labels = work(r.labels)
+    if (labels === r.labels) return state
+    return dotProp.set(state, ["byId", recipeId], lo =>
+        lo.map(r => ({
+            ...r,
+            labels,
+        })))
+}
+
+export const isRecipeStaged = r => {
+    if (r == null) return false
+    if (r instanceof LoadObject) {
+        if (!r.hasValue()) return false
+        r = r.getValueEnforcing()
+    }
+    if (!r.labels) return false
+    return r.labels.indexOf(LABEL_STAGED_INDICATOR) >= 0
+}
 
 class LibraryStore extends ReduceStore {
 
@@ -28,7 +53,6 @@ class LibraryStore extends ReduceStore {
             // used for bootstrapping (at the moment)
             recipeIds: LoadObject.empty(), // LoadObject<ID[]>
             scope: SCOPE_MINE,
-            stagedIds: [], // ID[]
             filter: ""
         }
     }
@@ -150,29 +174,15 @@ class LibraryStore extends ReduceStore {
             }
 
             case LibraryActions.STAGE_RECIPE: {
-                const stagedIds = addDistinct(state.stagedIds, action.id)
-                if (state.stagedIds === stagedIds) return state
-                return {
-                    ...state,
-                    stagedIds,
-                }
+                RecipeApi.addLabel(action.id, LABEL_STAGED_INDICATOR)
+                return workOnLabels(state, action.id, labels =>
+                    addDistinct(labels, LABEL_STAGED_INDICATOR))
             }
 
             case LibraryActions.UNSTAGE_RECIPE: {
-                const stagedIds = removeDistinct(state.stagedIds, action.id)
-                if (state.stagedIds === stagedIds) return state
-                return {
-                    ...state,
-                    stagedIds,
-                }
-            }
-
-            case LibraryActions.UNSTAGE_ALL_RECIPES: {
-                if (state.stagedIds.length === 0) return state
-                return {
-                    ...state,
-                    stagedIds: [],
-                }
+                RecipeApi.removeLabel(action.id, LABEL_STAGED_INDICATOR)
+                return workOnLabels(state, action.id, labels =>
+                    removeDistinct(labels, LABEL_STAGED_INDICATOR))
             }
 
             default: {
@@ -212,24 +222,21 @@ class LibraryStore extends ReduceStore {
         return this.getIngredientById(selectedRecipe)
     }
 
-    getStagedIds() {
-        return this.getState().stagedIds
-    }
-
     getStagedRecipes() {
-        return this.getStagedIds()
-            .map(id => this.getIngredientById(id))
-            .filter(lo => lo.hasValue())
-            .map(lo => lo.getValueEnforcing())
+        if (this.getState().scope !== SCOPE_MINE) return []
+        const lo = this.getLibraryLO()
+        if (!lo.hasValue()) return []
+        return lo.getValueEnforcing()
+            .filter(isRecipeStaged)
     }
 
     isStaged(id) {
-        return this.getState().stagedIds.indexOf(id) >= 0
+        return isRecipeStaged(this.getState().byId[id])
     }
 
     getShoppingList() {
-        const s = this.getState()
-        if (s.stagedIds.length === 0) return LoadObject.empty()
+        const recipes = this.getStagedRecipes()
+        if (recipes.length === 0) return LoadObject.empty()
         // i convert an IngredientRef to LoadObject<Map<id, Map<unit, amount>>>
         const raws = []
         const convert = ref => {
@@ -289,19 +296,14 @@ class LibraryStore extends ReduceStore {
         // this is a kludge, because currently when staging there is an implicit
         // "1 count" of the recipe. which will have to change, but for now we'll
         // just hard code it so the data structures are right. woo!
-        return s.stagedIds
-            .map(id => {
-                const lo = this.getIngredientById(id)
-                return {
-                    // an IngredientRef!
-                    ingredientId: id,
-                    quantity: 1,
-                    units: null,
-                    raw: lo.hasValue()
-                        ? "1 " + lo.getValueEnforcing().name
-                        : "staged ing " + id,
-                }
-            })
+        return recipes
+            .map(r => ({
+                // an IngredientRef!
+                ingredientId: r.id,
+                quantity: 1,
+                units: null,
+                raw: "1 " + r.name,
+            }))
             .map(convert)
             .reduce(merge)
             .map(items =>

--- a/client/src/data/RecipeActions.js
+++ b/client/src/data/RecipeActions.js
@@ -47,6 +47,15 @@ const RecipeActions = {
     NEW_DRAFT_INGREDIENT_YO: "recipe/new-draft-ingredient-yo",
     KILL_DRAFT_INGREDIENT_YO: "recipe/kill-draft-ingredient-yo",
     MULTI_LINE_DRAFT_INGREDIENT_PASTE_YO: "recipe/multi-line-draft-ingredient-paste-yo",
+
+    LABEL_ADDED: typedAction("recipe/label-added", {
+        id: PropTypes.number.isRequired,
+        label: PropTypes.string.isRequired,
+    }),
+    LABEL_REMOVED: typedAction("recipe/label-removed", {
+        id: PropTypes.number.isRequired,
+        label: PropTypes.string.isRequired,
+    }),
 }
 
 export default RecipeActions

--- a/client/src/data/RecipeApi.js
+++ b/client/src/data/RecipeApi.js
@@ -101,8 +101,32 @@ const RecipeApi = {
                 raw,
             }),
         )
-    }
-    
+    },
+
+    addLabel(id, label) {
+        promiseFlux(
+            // this endpoint wants a plain-text post body containing the label
+            axios.post(`/recipe/${id}/labels`, label, {
+                headers: { 'Content-Type': 'text/plain' }
+            }),
+            () => ({
+                type: RecipeActions.LABEL_ADDED,
+                id,
+                label,
+            }),
+        )
+    },
+
+    removeLabel(id, label) {
+        promiseFlux(
+            axios.delete(`/recipe/${id}/labels/${encodeURIComponent(label)}`),
+            () => ({
+                type: RecipeActions.LABEL_REMOVED,
+                id,
+                label,
+            }),
+        )
+    },
 }
 
 export default RecipeApi

--- a/client/src/data/RecipeTypes.js
+++ b/client/src/data/RecipeTypes.js
@@ -8,11 +8,12 @@ export const Ingredient = PropTypes.shape({
 })
 
 export const IngredientRef = PropTypes.shape({
-    amount: PropTypes.number,
+    quantity: PropTypes.number,
     preparation: PropTypes.string,
     units: PropTypes.string,
     raw: PropTypes.string,
-    ingredient: Ingredient
+    ingredient: PropTypes.string,
+    ingredientId: PropTypes.number,
 })
 
 export const Recipe = PropTypes.shape({

--- a/client/src/routes.js
+++ b/client/src/routes.js
@@ -15,6 +15,7 @@ const routes = {
     private: [
         {path: "/profile",  component: Profile},
         {path: "/library/recipe/:id/edit", component: RecipeEdit},
+        {path: "/library/recipe/:id/make-copy", component: RecipeAdd},
         {path: "/library/recipe/:id",   component: Recipe },
         {path: "/library",  component: Library},
         {path: "/add",      component: RecipeAdd},

--- a/client/src/views/RecipeDetail.js
+++ b/client/src/views/RecipeDetail.js
@@ -17,8 +17,10 @@ import { Recipe } from "../data/RecipeTypes"
 import history from "../util/history"
 import LibraryActions from "../data/LibraryActions"
 import LabelItem from "./LabelItem"
+import DeleteButton from "./common/DeleteButton"
+import RecipeApi from "../data/RecipeApi"
 
-const RecipeDetail = ({recipeLO, staged}) => {
+const RecipeDetail = ({recipeLO, mine, staged}) => {
 
     if (!recipeLO.hasValue()) {
         if (recipeLO.isLoading()) {
@@ -36,26 +38,35 @@ const RecipeDetail = ({recipeLO, staged}) => {
                     icon="close"
                     onClick={() => history.push("/library")}
                 >Close</Button>
-                {staged
+                {mine && (staged
                     ? <Button
-                        icon="delete"
+                        icon="export"
                         onClick={() => Dispatcher.dispatch({
                             type: LibraryActions.UNSTAGE_RECIPE,
                             id: recipe.id,
                         })}
                     >Unstage</Button>
                     : <Button
-                        icon="select"
+                        icon="import"
                         onClick={() => Dispatcher.dispatch({
                             type: LibraryActions.STAGE_RECIPE,
                             id: recipe.id,
                         })}
                     >Stage</Button>
-                }
+                )}
                 <Button
+                    icon="copy"
+                    onClick={() => history.push(`/library/recipe/${recipe.id}/make-copy`)}
+                >{mine ? "Copy" : "Duplicate to My Library"}</Button>
+                {mine && <Button
                     icon="edit"
                     onClick={() => history.push(`/library/recipe/${recipe.id}/edit`)}
-                >Edit</Button>
+                >Edit</Button>}
+                {mine && <DeleteButton
+                    type="recipe"
+                    label={"Delete"}
+                    onConfirm={() => RecipeApi.deleteRecipe(recipe.id)}
+                />}
             </Button.Group>
 
             <Affix offsetTop={0}>
@@ -91,15 +102,19 @@ const RecipeDetail = ({recipeLO, staged}) => {
                 <Directions text={recipe.directions} />
             </React.Fragment>}
             
-            {recipe.labels && recipe.labels.map( label => <LabelItem key={label} label={label} />)}
+            {recipe.labels && recipe.labels
+                .filter(label => label.indexOf("--") !== 0)
+                .map(label =>
+                    <LabelItem key={label} label={label} />)}
 
         </div>
     )
 }
 
 RecipeDetail.propTypes = {
-    recipeLO: loadObjectOf(Recipe),
-    staged: PropTypes.bool.isRequired,
+    recipeLO: loadObjectOf(Recipe).isRequired,
+    mine: PropTypes.bool,
+    staged: PropTypes.bool,
 }
 
 export default RecipeDetail

--- a/client/src/views/RecipeDetail.js
+++ b/client/src/views/RecipeDetail.js
@@ -19,8 +19,9 @@ import LibraryActions from "../data/LibraryActions"
 import LabelItem from "./LabelItem"
 import DeleteButton from "./common/DeleteButton"
 import RecipeApi from "../data/RecipeApi"
+import User from "./user/User"
 
-const RecipeDetail = ({recipeLO, mine, staged}) => {
+const RecipeDetail = ({recipeLO, mine, staged, ownerLO}) => {
 
     if (!recipeLO.hasValue()) {
         if (recipeLO.isLoading()) {
@@ -69,7 +70,11 @@ const RecipeDetail = ({recipeLO, mine, staged}) => {
                 />}
             </Button.Group>
 
+
             <Affix offsetTop={0}>
+                {!mine && ownerLO.hasValue() && <p style={{float: "right"}}>
+                    <User {...ownerLO.getValueEnforcing()} />
+                </p>}
                 <h2 style={{
                     backgroundColor: "white",
                 }}>{recipe.name}</h2>
@@ -114,6 +119,7 @@ const RecipeDetail = ({recipeLO, mine, staged}) => {
 RecipeDetail.propTypes = {
     recipeLO: loadObjectOf(Recipe).isRequired,
     mine: PropTypes.bool,
+    ownerLO: loadObjectOf(PropTypes.object),
     staged: PropTypes.bool,
 }
 

--- a/client/src/views/RecipeListItem.js
+++ b/client/src/views/RecipeListItem.js
@@ -14,51 +14,53 @@ import { LABEL_STAGED_INDICATOR } from "../data/LibraryStore"
 
 const {Item} = List
 
-const RecipeListItem = ({recipe, staged}) => {
+const RecipeListItem = ({recipe, mine, staged}) => {
     const labelString = (recipe.labels || [])
         .filter(l =>
             l !== LABEL_STAGED_INDICATOR)
         .sort()
         .join(", ")
+    const actions = []
+    if (mine) {
+        actions.push(staged
+            ? <Button key="unstage"
+                      shape="circle"
+                      icon="delete"
+                      size="small"
+                      title="Unstage recipe"
+                      onClick={e => {
+                          e.preventDefault()
+                          Dispatcher.dispatch({
+                              type: LibraryActions.UNSTAGE_RECIPE,
+                              id: recipe.id,
+                          })
+                      }}
+            />
+            : <Button key="stage"
+                      shape="circle"
+                      icon="select"
+                      size="small"
+                      title="Stage recipe"
+                      onClick={e => {
+                          e.preventDefault()
+                          Dispatcher.dispatch({
+                              type: LibraryActions.STAGE_RECIPE,
+                              id: recipe.id,
+                          })
+                      }}
+            />)
+    }
+    actions.push(<Link key="edit"
+                       to={`/library/recipe/${recipe.id}/edit`}><EditButton /></Link>)
     return (
         <Item
             key={recipe.id}
             onClick={event =>
                 event.defaultPrevented || history.push(`/library/recipe/${recipe.id}`)}
             style={{cursor: "pointer"}}
-            actions={[
-                staged
-                    ? <Button key="unstage"
-                              shape="circle"
-                              icon="delete"
-                              size="small"
-                              title="Unstage recipe"
-                              onClick={e => {
-                                  e.preventDefault()
-                                  Dispatcher.dispatch({
-                                      type: LibraryActions.UNSTAGE_RECIPE,
-                                      id: recipe.id,
-                                  })
-                              }}
-                    />
-                    : <Button key="stage"
-                              shape="circle"
-                              icon="select"
-                              size="small"
-                              title="Stage recipe"
-                              onClick={e => {
-                                  e.preventDefault()
-                                  Dispatcher.dispatch({
-                                      type: LibraryActions.STAGE_RECIPE,
-                                      id: recipe.id,
-                                  })
-                              }}
-                    />,
-                <Link key="edit"
-                      to={`/library/recipe/${recipe.id}/edit`}><EditButton /></Link>,
-            ]}>
+            actions={actions}>
             <List.Item.Meta
-                title={recipe.name}
+                title={recipe.name + " (" + (mine ? "ME" : "OTHER") + ")"}
                 description={labelString}
             />
         </Item>
@@ -67,6 +69,7 @@ const RecipeListItem = ({recipe, staged}) => {
 
 RecipeListItem.propTypes = {
     recipe: Recipe,
+    mine: PropTypes.bool,
     staged: PropTypes.bool,
 }
 

--- a/client/src/views/RecipeListItem.js
+++ b/client/src/views/RecipeListItem.js
@@ -20,14 +20,13 @@ const RecipeListItem = ({recipe, mine, staged}) => {
             l !== LABEL_STAGED_INDICATOR)
         .sort()
         .join(", ")
-    const actions = []
-    if (mine) {
-        actions.push(staged
-            ? <Button key="unstage"
-                      shape="circle"
-                      icon="delete"
-                      size="small"
-                      title="Unstage recipe"
+    const actions = mine
+        ? [staged
+            ? <Button key={"unstage"}
+                      shape={"circle"}
+                      icon={"export"}
+                      size={"small"}
+                      title={"Unstage recipe"}
                       onClick={e => {
                           e.preventDefault()
                           Dispatcher.dispatch({
@@ -36,11 +35,11 @@ const RecipeListItem = ({recipe, mine, staged}) => {
                           })
                       }}
             />
-            : <Button key="stage"
-                      shape="circle"
-                      icon="select"
-                      size="small"
-                      title="Stage recipe"
+            : <Button key={"stage"}
+                      shape={"circle"}
+                      icon={"import"}
+                      size={"small"}
+                      title={"Stage recipe"}
                       onClick={e => {
                           e.preventDefault()
                           Dispatcher.dispatch({
@@ -48,10 +47,11 @@ const RecipeListItem = ({recipe, mine, staged}) => {
                               id: recipe.id,
                           })
                       }}
-            />)
-    }
-    actions.push(<Link key="edit"
-                       to={`/library/recipe/${recipe.id}/edit`}><EditButton /></Link>)
+            />,
+            <Link key="edit"
+                  to={`/library/recipe/${recipe.id}/edit`}><EditButton /></Link>,
+        ]
+        : null
     return (
         <Item
             key={recipe.id}
@@ -60,7 +60,7 @@ const RecipeListItem = ({recipe, mine, staged}) => {
             style={{cursor: "pointer"}}
             actions={actions}>
             <List.Item.Meta
-                title={recipe.name + " (" + (mine ? "ME" : "OTHER") + ")"}
+                title={recipe.name}
                 description={labelString}
             />
         </Item>

--- a/client/src/views/RecipeListItem.js
+++ b/client/src/views/RecipeListItem.js
@@ -10,10 +10,16 @@ import EditButton from "./common/EditButton"
 import { Recipe } from "../data/RecipeTypes"
 import history from "../util/history"
 import LibraryActions from "../data/LibraryActions"
+import { LABEL_STAGED_INDICATOR } from "../data/LibraryStore"
 
 const {Item} = List
 
 const RecipeListItem = ({recipe, staged}) => {
+    const labelString = (recipe.labels || [])
+        .filter(l =>
+            l !== LABEL_STAGED_INDICATOR)
+        .sort()
+        .join(", ")
     return (
         <Item
             key={recipe.id}
@@ -53,7 +59,7 @@ const RecipeListItem = ({recipe, staged}) => {
             ]}>
             <List.Item.Meta
                 title={recipe.name}
-                description={recipe.labels && recipe.labels.length ? recipe.labels.sort().join(", ") : null}
+                description={labelString}
             />
         </Item>
     )

--- a/client/src/views/RecipesList.js
+++ b/client/src/views/RecipesList.js
@@ -49,13 +49,11 @@ const RecipesList = (props: {}) => {
         return <Spin tip="Loading recipe library..."/>
     }
 
-    const [library, stagedRecipes] = scope === SCOPE_MINE
-        ? libraryLO.getValueEnforcing()
-            .reduce((part, r) => {
-                part[isRecipeStaged(r) ? 1 : 0].push(r)
-                return part
-            }, [[], []])
-        : [libraryLO.getValueEnforcing(), []]
+    const [library, stagedRecipes] = libraryLO.getValueEnforcing()
+        .reduce((part, r) => {
+            part[r.ownerId === me.id && isRecipeStaged(r) ? 1 : 0].push(r)
+            return part
+        }, [[], []])
     const hasStage = stagedRecipes.length > 0
 
     const list = hasStage && <Card
@@ -77,7 +75,7 @@ const RecipesList = (props: {}) => {
         itemLayout="horizontal"
         renderItem={recipe =>
             <RecipeListItem recipe={recipe}
-                            mine={recipe.ownerId === me.id}
+                            mine
                             staged />}
         footer={<Button.Group>
             <AddToList

--- a/client/src/views/RecipesList.js
+++ b/client/src/views/RecipesList.js
@@ -43,7 +43,7 @@ const sendFilter = (e) => {
 }
 
 const RecipesList = (props: {}) => {
-    const {filter, scope, libraryLO, shoppingList} = props
+    const {me, filter, scope, libraryLO, shoppingList} = props
     
     if (!libraryLO.hasValue()) {
         return <Spin tip="Loading recipe library..."/>
@@ -75,8 +75,10 @@ const RecipesList = (props: {}) => {
     const stage = hasStage && <List
         dataSource={stagedRecipes}
         itemLayout="horizontal"
-        renderItem={recipe => <RecipeListItem recipe={recipe}
-                                              staged />}
+        renderItem={recipe =>
+            <RecipeListItem recipe={recipe}
+                            mine={recipe.ownerId === me.id}
+                            staged />}
         footer={<Button.Group>
             <AddToList
                 key="add-to-list"
@@ -99,7 +101,9 @@ const RecipesList = (props: {}) => {
         <List
             dataSource={library}
             itemLayout="horizontal"
-            renderItem={recipe => <RecipeListItem recipe={recipe} />}
+            renderItem={recipe =>
+                <RecipeListItem recipe={recipe}
+                                mine={recipe.ownerId === me.id} />}
         />
     </React.Fragment>
 
@@ -136,6 +140,7 @@ RecipesList.defaultProps = {
 }
 
 RecipesList.propTypes = {
+    me: PropTypes.object.isRequired,
     libraryLO: loadObjectOf(PropTypes.arrayOf(Recipe)).isRequired,
     filter: PropTypes.string,
     scope: PropTypes.string,

--- a/client/src/views/RecipesList.js
+++ b/client/src/views/RecipesList.js
@@ -4,7 +4,9 @@ import Dispatcher from "../data/dispatcher"
 import {
     Button,
     Card,
+    Col,
     List,
+    Row,
     Spin,
     Switch,
 } from "antd"
@@ -17,6 +19,7 @@ import LibraryActions from "../data/LibraryActions"
 import ShoppingListItem from "./ShoppingListItem"
 import SearchFilter from "./SearchFilter"
 import {
+    isRecipeStaged,
     SCOPE_EVERYONE,
     SCOPE_MINE,
 } from "../data/LibraryStore"
@@ -40,90 +43,91 @@ const sendFilter = (e) => {
 }
 
 const RecipesList = (props: {}) => {
-    const {filter, scope, libraryLO, stagedRecipes, shoppingList} = props
+    const {filter, scope, libraryLO, shoppingList} = props
     
     if (!libraryLO.hasValue()) {
         return <Spin tip="Loading recipe library..."/>
     }
 
-    const stagedIds = new Set()
-    for (const r of stagedRecipes) {
-        stagedIds.add(r.id)
-    }
-    const library = libraryLO.getValueEnforcing()
-        .filter(r => !stagedIds.has(r.id))
-    return (
-        <div className="recipes-list">
-            <div style={{float: "right"}}>
-                <Switch checked={scope === SCOPE_EVERYONE}
-                        checkedChildren="Everyone"
-                        unCheckedChildren="Mine"
-                        onChange={everyone => Dispatcher.dispatch({
-                            type: LibraryActions.SET_SCOPE,
-                            scope: everyone ? SCOPE_EVERYONE : SCOPE_MINE,
-                        })}
-                />
-            </div>
-            
-            <h1>Recipe Library</h1>
-    
-            <SearchFilter
-                onChange={updateFilter}
-                onFilter={sendFilter}
-                term={filter}
-                />
-            
-            {stagedRecipes.length > 0 && <React.Fragment>
-                <Card
-                    title="Shopping List"
+    const [library, stagedRecipes] = scope === SCOPE_MINE
+        ? libraryLO.getValueEnforcing()
+            .reduce((part, r) => {
+                part[isRecipeStaged(r) ? 1 : 0].push(r)
+                return part
+            }, [[], []])
+        : [libraryLO.getValueEnforcing(), []]
+    const hasStage = stagedRecipes.length > 0
+
+    const list = hasStage && <Card
+        title="Shopping List"
+        size="small"
+        style={{
+            marginLeft: "1em",
+        }}>
+        {shoppingList.hasValue()
+            ? <List dataSource={shoppingList.getValueEnforcing()}
                     size="small"
-                    style={{
-                        float:"right",
-                        maxWidth: "50%",
-                        margin: "0 0 2em 2em",
-                    }}>
-                    {shoppingList.hasValue()
-                        ? <List dataSource={shoppingList.getValueEnforcing()}
-                                size="small"
-                                split={false}
-                                renderItem={ShoppingListItem}/>
-                        : <Spin tip="Generating list..." />}
-                </Card>
-                <h2>Staged</h2>
-                <List
-                    dataSource={stagedRecipes}
-                    itemLayout="horizontal"
-                    renderItem={recipe => <RecipeListItem recipe={recipe}
-                                                          staged />}
-                    footer={<Button.Group>
-                        <Button
-                            key="unstage-all"
-                            shape="round"
-                            size="small"
-                            icon="delete"
-                            onClick={() => Dispatcher.dispatch({
-                                type: LibraryActions.UNSTAGE_ALL_RECIPES,
-                            })}
-                        >Unstage All</Button>
-                        <AddToList
-                            key="add-to-list"
-                            onClick={listId => Dispatcher.dispatch({
-                                type: RecipeActions.ASSEMBLE_SHOPPING_LIST,
-                                recipeIds: [...stagedIds],
-                                listId,
-                            })}
-                        />
-                    </Button.Group>}
-                />
-                <h2>Everything Else</h2>
-            </React.Fragment>}
-            <List
-                dataSource={library}
-                itemLayout="horizontal"
-                renderItem={recipe => <RecipeListItem recipe={recipe}/>}
+                    split={false}
+                    renderItem={ShoppingListItem} />
+            : <Spin tip="Generating list..." />}
+    </Card>
+
+    const stage = hasStage && <List
+        dataSource={stagedRecipes}
+        itemLayout="horizontal"
+        renderItem={recipe => <RecipeListItem recipe={recipe}
+                                              staged />}
+        footer={<Button.Group>
+            <AddToList
+                key="add-to-list"
+                onClick={listId => Dispatcher.dispatch({
+                    type: RecipeActions.ASSEMBLE_SHOPPING_LIST,
+                    recipeIds: stagedRecipes.map(r => r.id),
+                    listId,
+                })}
+            />
+        </Button.Group>}
+    />
+
+    const content = <React.Fragment>
+        <SearchFilter
+            onChange={updateFilter}
+            onFilter={sendFilter}
+            term={filter}
+        />
+
+        <List
+            dataSource={library}
+            itemLayout="horizontal"
+            renderItem={recipe => <RecipeListItem recipe={recipe} />}
+        />
+    </React.Fragment>
+
+    return <React.Fragment>
+        <div style={{float: "right"}}>
+            <Switch checked={scope === SCOPE_EVERYONE}
+                    checkedChildren="Everyone"
+                    unCheckedChildren="Mine"
+                    onChange={everyone => Dispatcher.dispatch({
+                        type: LibraryActions.SET_SCOPE,
+                        scope: everyone ? SCOPE_EVERYONE : SCOPE_MINE,
+                    })}
             />
         </div>
-    )
+
+        <h1>Recipe Library</h1>
+        <Row>
+            <Col span={hasStage ? 18 : 24}>
+                {hasStage && <React.Fragment>
+                    <h2>Staged</h2>
+                    {stage}
+                    <h2>Everything Else</h2>
+                </React.Fragment>}
+                {content}
+            </Col>
+            {hasStage && <Col span={6}>{list}</Col>}
+        </Row>
+    </React.Fragment>
 }
 
 RecipesList.defaultProps = {
@@ -133,9 +137,9 @@ RecipesList.defaultProps = {
 
 RecipesList.propTypes = {
     libraryLO: loadObjectOf(PropTypes.arrayOf(Recipe)).isRequired,
-    stagedRecipes: PropTypes.arrayOf(Recipe).isRequired,
     filter: PropTypes.string,
-    scope: PropTypes.string
+    scope: PropTypes.string,
+    shoppingList: loadObjectOf(PropTypes.array),
 }
 
 export default RecipesList

--- a/client/src/views/common/DeleteButton.js
+++ b/client/src/views/common/DeleteButton.js
@@ -17,6 +17,7 @@ const DeleteButton = ({type, onConfirm, label = "Delete " + capitalize(type), on
     >
         <Button
             type="danger"
+            icon={"delete"}
             onClick={onClick}
         >{label}</Button>
     </Popconfirm>

--- a/client/src/views/common/EditButton.js
+++ b/client/src/views/common/EditButton.js
@@ -2,8 +2,7 @@ import React from 'react'
 import { Button } from "antd"
 
 const EditButton = () => {
-    return <Button type="primary"
-                   shape="circle"
+    return <Button shape="circle"
                    icon="edit"
                    size="small"/>
 }

--- a/client/src/views/user/User.js
+++ b/client/src/views/user/User.js
@@ -7,11 +7,14 @@ const User = ({
                   email,
                   imageUrl,
                   size = "small",
+    iconOnly = false,
               }) =>
-    <span title={email}>
+    <span title={iconOnly ? name ? `${name} <${email}>` : email : email}>
         <Avatar src={imageUrl} size={size}>{(name || email || "U").charAt(0).toUpperCase()}</Avatar>
-        {" "}
-        {name || email}
+        {!iconOnly && <React.Fragment>
+            {" "}
+            {name || email}
+        </React.Fragment>}
     </span>
 
 User.propTypes = {
@@ -26,6 +29,7 @@ User.propTypes = {
         ]),
         PropTypes.number,
     ]),
+    iconOnly: PropTypes.bool,
 }
 
 export default User

--- a/src/main/java/com/brennaswitzer/cookbook/payload/IngredientInfo.java
+++ b/src/main/java/com/brennaswitzer/cookbook/payload/IngredientInfo.java
@@ -3,10 +3,8 @@ package com.brennaswitzer.cookbook.payload;
 import com.brennaswitzer.cookbook.domain.*;
 
 import javax.persistence.EntityManager;
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 public class IngredientInfo {
@@ -149,6 +147,7 @@ public class IngredientInfo {
     private String directions;
     private List<Ref> ingredients;
     private List<String> labels;
+    private Long ownerId;
 
     public Long getId() {
         return id;
@@ -206,6 +205,14 @@ public class IngredientInfo {
         this.labels = labels;
     }
 
+    public Long getOwnerId() {
+        return ownerId;
+    }
+
+    public void setOwnerId(Long ownerId) {
+        this.ownerId = ownerId;
+    }
+
     public Recipe asRecipe(EntityManager em) {
         Recipe r = getId() == null
                 ? new Recipe()
@@ -231,6 +238,9 @@ public class IngredientInfo {
                 .stream()
                 .map(Label::getName)
                 .collect(Collectors.toList()));
+        if (r.getOwner() != null) {
+            info.setOwnerId(r.getOwner().getId());
+        }
         return info;
     }
 

--- a/src/main/java/com/brennaswitzer/cookbook/services/LabelService.java
+++ b/src/main/java/com/brennaswitzer/cookbook/services/LabelService.java
@@ -27,6 +27,10 @@ public class LabelService {
         l.addLabel(ensureLabel(label));
     }
 
+    public void removeLabel(Labeled l, String label) {
+        l.removeLabel(ensureLabel(label));
+    }
+
     public void updateLabels(Labeled l, List<String> labels) {
         // loop through the array of strings and make a Label out of each of them
         // and then clear out whatever was in the Labeled and add all the new shit

--- a/src/main/java/com/brennaswitzer/cookbook/web/RecipeController.java
+++ b/src/main/java/com/brennaswitzer/cookbook/web/RecipeController.java
@@ -17,9 +17,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.validation.Valid;
-import javax.xml.ws.Response;
 import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -137,6 +135,17 @@ public class RecipeController {
         Recipe recipe = getRecipe(id);
         labelService.addLabel(recipe, label);
         return new ResponseEntity<>(label, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}/labels/{label}")
+    @Transactional
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void removeLable(
+            @PathVariable Long id,
+            @PathVariable String label
+    ) {
+        Recipe recipe = getRecipe(id);
+        labelService.removeLabel(recipe, label);
     }
 
     @PostMapping("/_actions")


### PR DESCRIPTION
In lieu of the full planner, provide the ability to semi-gracefully copy recipes as a way to get an ephemeral copy to munge before sending it to the task list. "Copy" is a slight misnomer - the actual behaviour is really "populate the Add Recipe form w/ an existing recipe's data". The "copy" isn't saved until you hit save on the form. The assumption being that if you want to copy something, you're never going to actually want an exact copy. :)

Along with that main thrust:
* make the staging area persistent (via an `--on-stage` label)
* better differentiate recipe ownership and the actions you can take based on "mine or not"
* move scope/filter to just the recipe list (not the stage)